### PR TITLE
transfer_with_transact

### DIFF
--- a/xtokens/Cargo.toml
+++ b/xtokens/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 scale-info = { version = "2.1.2", default-features = false, features = ["derive"] }
 serde = { version = "1.0.136", optional = true }
 codec = { package = "parity-scale-codec", version = "3.0.0", default-features = false }
+log = "0.4.16"
 
 # substrate
 sp-runtime = { git = "https://github.com/paritytech/substrate", default-features = false , branch = "polkadot-v0.9.24" }
@@ -59,6 +60,7 @@ std = [
 	"serde",
 	"codec/std",
 	"scale-info/std",
+	"log/std",
 	"sp-runtime/std",
 	"sp-std/std",
 	"sp-io/std",

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -532,7 +532,7 @@ pub mod module {
 					fees: transact_fee_asset,
 					// TODO: make it work with Limited...
 					// weight_limit: WeightLimit::Limited(dest_weight),
-					weight_limit: WeightLimit::Unlimited,
+					weight_limit: WeightLimit::Limited(dest_weight),
 				},
 				Transact {
 					// SovereignAccount of the user, not the chain

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -738,6 +738,7 @@ pub mod module {
 				let mut assets_to_fee_reserve = MultiAssets::new();
 				let asset_to_fee_reserve = subtract_fee(&fee, min_xcm_fee);
 				assets_to_fee_reserve.push(asset_to_fee_reserve.clone());
+				println!("im not here right ?////////////////////////////////  \n");
 
 				// First xcm sent to fee reserve chain and routed to dest chain.
 				Self::execute_and_send_reserve_kind_xcm(
@@ -806,6 +807,7 @@ pub mod module {
 			};
 
 			let weight = T::Weigher::weight(&mut msg).map_err(|()| Error::<T>::UnweighableMessage)?;
+			println!("origin_location: {:?} \n", origin_location);
 			T::XcmExecutor::execute_xcm_in_credit(origin_location, msg, weight, weight)
 				.ensure_complete()
 				.map_err(|error| {

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -530,7 +530,9 @@ pub mod module {
 				WithdrawAsset(transact_fee_assets.clone()),
 				BuyExecution {
 					fees: transact_fee_asset,
-					weight_limit: WeightLimit::Limited(dest_weight),
+					// TODO: make it work with Limited...
+					// weight_limit: WeightLimit::Limited(dest_weight),
+					weight_limit: WeightLimit::Unlimited,
 				},
 				Transact {
 					// SovereignAccount of the user, not the chain

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -195,14 +195,30 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTransactFrom<T> {
 				ref mut weight_limit, ..
 			} => {
 				*weight_limit = Limited(max_weight);
-				Ok(())
 			}
 			_ => {
 				println!("AllowTransactFrom 4");
 
-				Err(())
+				return Err(());
 			}
 		}
+		let i = iter.next().ok_or(())?;
+		match i {
+			Transact { .. } => (),
+			_ => return Err(()),
+		}
+		let i = iter.next().ok_or(())?;
+		match i {
+			RefundSurplus { .. } => (),
+			_ => return Err(()),
+		}
+		let i = iter.next().ok_or(())?;
+		match i {
+			DepositAsset { .. } => (),
+			_ => return Err(()),
+		}
+
+		Ok(())
 	}
 }
 pub type Barrier = (

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -192,17 +192,8 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTransactFrom<T> {
 		println!("AllowTransactFrom i: {:?} \n", i);
 		match i {
 			BuyExecution {
-				weight_limit: Limited(ref mut weight),
-				..
-			} => {
-				// max_weight will always be more than weight because
-				// max_weight = weight + weigher::weight(incoming_message)
-				*weight = max_weight;
-				Ok(())
-			}
-			BuyExecution {
 				ref mut weight_limit, ..
-			} if weight_limit == &Unlimited => {
+			} => {
 				*weight_limit = Limited(max_weight);
 				Ok(())
 			}

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -196,7 +196,8 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTransactFrom<T> {
 		}
 		let next_instruction = iter.next().ok_or(())?;
 		match next_instruction {
-			// TODO: can at least check the length of the encoded vec<u8>, need a PR in polkadot for that
+			// TODO: can at least check the length of the encoded vec<u8>, need a PR in polkadot for that.
+			// Also the allowed length could be configurable.
 			// TODO: if possible decode the call and match against a configurable set of allowed calls
 			Transact { .. } => (),
 			_ => return Err(()),
@@ -238,7 +239,6 @@ impl WeightTrader for AllTokensAreCreatedEqualToWeight {
 			.next()
 			.expect("Payment must be something; qed")
 			.0;
-
 		let required = MultiAsset {
 			id: asset_id.clone(),
 			fun: Fungible(weight as u128),
@@ -253,7 +253,6 @@ impl WeightTrader for AllTokensAreCreatedEqualToWeight {
 		}
 
 		let unused = payment.checked_sub(required).map_err(|_| XcmError::TooExpensive)?;
-
 		Ok(unused)
 	}
 
@@ -392,7 +391,6 @@ impl orml_xtokens::Config for Runtime {
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type ReserveProvider = AbsoluteReserveProvider;
 	type XcmSender = XcmRouter;
-	type MaxTransactSize = ConstU32<256>;
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -194,7 +194,9 @@ impl<T: Contains<MultiLocation>> ShouldExecute for AllowTransactFrom<T> {
 			BuyExecution {
 				weight_limit: Limited(ref mut weight),
 				..
-			} if *weight >= max_weight => {
+			} => {
+				// max_weight will always be more than weight because
+				// max_weight = weight + weigher::weight(incoming_message)
 				*weight = max_weight;
 				Ok(())
 			}

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -110,11 +110,13 @@ parameter_types! {
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
 }
 
+pub type MyAccount32Hash = Account32Hash<RelayNetwork, AccountId>;
+
 pub type LocationToAccountId = (
 	ParentIsPreset<AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
-	Account32Hash<RelayNetwork, AccountId>,
+	MyAccount32Hash,
 );
 
 pub type XcmOriginToCallOrigin = (
@@ -270,6 +272,8 @@ impl WeightTrader for AllTokensAreCreatedEqualToWeight {
 	}
 }
 
+pub type FixedWeigher = FixedWeightBounds<ConstU64<10>, Call, ConstU32<100>>;
+
 pub struct XcmConfig;
 impl Config for XcmConfig {
 	type Call = Call;
@@ -280,7 +284,7 @@ impl Config for XcmConfig {
 	type IsTeleporter = ();
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
-	type Weigher = FixedWeightBounds<ConstU64<10>, Call, ConstU32<100>>;
+	type Weigher = FixedWeigher;
 	type Trader = AllTokensAreCreatedEqualToWeight;
 	type ResponseHandler = ();
 	type AssetTrap = PolkadotXcm;
@@ -331,7 +335,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Nothing;
 	type XcmReserveTransferFilter = Everything;
-	type Weigher = FixedWeightBounds<ConstU64<10>, Call, ConstU32<100>>;
+	type Weigher = FixedWeigher;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;
@@ -388,7 +392,7 @@ impl orml_xtokens::Config for Runtime {
 	type MultiLocationsFilter = ParentOrParachains;
 	type MinXcmFee = ParachainMinFee;
 	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type Weigher = FixedWeightBounds<ConstU64<10>, Call, ConstU32<100>>;
+	type Weigher = FixedWeigher;
 	type BaseXcmWeight = ConstU64<100_000_000>;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;

--- a/xtokens/src/mock/para.rs
+++ b/xtokens/src/mock/para.rs
@@ -109,13 +109,12 @@ parameter_types! {
 	pub Ancestry: MultiLocation = Parachain(ParachainInfo::parachain_id().into()).into();
 }
 
-pub type MyAccount32Hash = Account32Hash<RelayNetwork, AccountId>;
-
+pub type ParaAccount32Hash = Account32Hash<RelayNetwork, AccountId>;
 pub type LocationToAccountId = (
 	ParentIsPreset<AccountId>,
 	SiblingParachainConvertsVia<Sibling, AccountId>,
 	AccountId32Aliases<RelayNetwork, AccountId>,
-	MyAccount32Hash,
+	ParaAccount32Hash,
 );
 
 pub type XcmOriginToCallOrigin = (

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -326,7 +326,6 @@ impl Convert<MultiAsset, Option<CurrencyId>> for RelativeCurrencyIdConvert {
 parameter_types! {
 	pub SelfLocation: MultiLocation = MultiLocation::here();
 	pub const MaxAssetsForTransfer: usize = 2;
-	pub const MaxTransactSize: u32 = 256;
 }
 
 match_types! {
@@ -367,7 +366,6 @@ impl orml_xtokens::Config for Runtime {
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type ReserveProvider = RelativeReserveProvider;
 	type XcmSender = XcmRouter;
-	type MaxTransactSize = MaxTransactSize;
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/para_relative_view.rs
+++ b/xtokens/src/mock/para_relative_view.rs
@@ -326,6 +326,7 @@ impl Convert<MultiAsset, Option<CurrencyId>> for RelativeCurrencyIdConvert {
 parameter_types! {
 	pub SelfLocation: MultiLocation = MultiLocation::here();
 	pub const MaxAssetsForTransfer: usize = 2;
+	pub const MaxTransactSize: u32 = 256;
 }
 
 match_types! {
@@ -365,6 +366,8 @@ impl orml_xtokens::Config for Runtime {
 	type LocationInverter = LocationInverter<Ancestry>;
 	type MaxAssetsForTransfer = MaxAssetsForTransfer;
 	type ReserveProvider = RelativeReserveProvider;
+	type XcmSender = XcmRouter;
+	type MaxTransactSize = MaxTransactSize;
 }
 
 impl orml_xcm::Config for Runtime {

--- a/xtokens/src/mock/relay.rs
+++ b/xtokens/src/mock/relay.rs
@@ -89,6 +89,8 @@ type LocalOriginConverter = (
 pub type XcmRouter = super::RelayChainXcmRouter;
 pub type Barrier = (TakeWeightCredit, AllowTopLevelPaidExecutionFrom<Everything>);
 
+pub type RelayWeigher = FixedWeightBounds<ConstU64<10>, Call, ConstU32<100>>;
+
 pub struct XcmConfig;
 impl Config for XcmConfig {
 	type Call = Call;
@@ -99,7 +101,7 @@ impl Config for XcmConfig {
 	type IsTeleporter = ();
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Barrier = Barrier;
-	type Weigher = FixedWeightBounds<ConstU64<10>, Call, ConstU32<100>>;
+	type Weigher = RelayWeigher;
 	type Trader = UsingComponents<IdentityFee<Balance>, KsmLocation, AccountId, Balances, ()>;
 	type ResponseHandler = ();
 	type AssetTrap = ();
@@ -119,7 +121,7 @@ impl pallet_xcm::Config for Runtime {
 	type XcmExecutor = XcmExecutor<XcmConfig>;
 	type XcmTeleportFilter = Everything;
 	type XcmReserveTransferFilter = Everything;
-	type Weigher = FixedWeightBounds<ConstU64<10>, Call, ConstU32<100>>;
+	type Weigher = RelayWeigher;
 	type LocationInverter = LocationInverter<Ancestry>;
 	type Origin = Origin;
 	type Call = Call;

--- a/xtokens/src/mock/relay.rs
+++ b/xtokens/src/mock/relay.rs
@@ -11,9 +11,9 @@ use cumulus_primitives_core::ParaId;
 use polkadot_runtime_parachains::{configuration, origin, shared, ump};
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	Account32Hash, AccountId32Aliases, AllowTopLevelPaidExecutionFrom, ChildParachainAsNative,
-	ChildParachainConvertsVia, CurrencyAdapter as XcmCurrencyAdapter, FixedWeightBounds, IsConcrete, LocationInverter,
-	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, ChildParachainAsNative, ChildParachainConvertsVia,
+	CurrencyAdapter as XcmCurrencyAdapter, FixedWeightBounds, IsConcrete, LocationInverter, SignedAccountId32AsNative,
+	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -74,7 +74,6 @@ parameter_types! {
 pub type SovereignAccountOf = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	AccountId32Aliases<KusamaNetwork, AccountId>,
-	// Account32Hash<KusamaNetwork, AccountId>,
 );
 
 pub type LocalAssetTransactor =

--- a/xtokens/src/mock/relay.rs
+++ b/xtokens/src/mock/relay.rs
@@ -11,9 +11,9 @@ use cumulus_primitives_core::ParaId;
 use polkadot_runtime_parachains::{configuration, origin, shared, ump};
 use xcm::latest::prelude::*;
 use xcm_builder::{
-	AccountId32Aliases, AllowTopLevelPaidExecutionFrom, ChildParachainAsNative, ChildParachainConvertsVia,
-	CurrencyAdapter as XcmCurrencyAdapter, FixedWeightBounds, IsConcrete, LocationInverter, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
+	Account32Hash, AccountId32Aliases, AllowTopLevelPaidExecutionFrom, ChildParachainAsNative,
+	ChildParachainConvertsVia, CurrencyAdapter as XcmCurrencyAdapter, FixedWeightBounds, IsConcrete, LocationInverter,
+	SignedAccountId32AsNative, SignedToAccountId32, SovereignSignedViaLocation, TakeWeightCredit, UsingComponents,
 };
 use xcm_executor::{Config, XcmExecutor};
 
@@ -74,6 +74,7 @@ parameter_types! {
 pub type SovereignAccountOf = (
 	ChildParachainConvertsVia<ParaId, AccountId>,
 	AccountId32Aliases<KusamaNetwork, AccountId>,
+	// Account32Hash<KusamaNetwork, AccountId>,
 );
 
 pub type LocalAssetTransactor =

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -320,7 +320,8 @@ fn transfer_with_transact_self_reserve_sibling() {
 
 	let transfer_amount = 50_000u128;
 	let transact_fee_amount = 10_000u128;
-	let dest_weight = 4_000;
+	let transfer_dest_weight = 4_000;
+	let transact_dest_weight = 4_000;
 
 	ParaA::execute_with(|| {
 		assert_ok!(ParaXTokens::transfer_with_transact(
@@ -328,9 +329,10 @@ fn transfer_with_transact_self_reserve_sibling() {
 			CurrencyId::A,
 			transfer_amount,
 			2, // PARA_B_ID,
-			dest_weight,
+			transfer_dest_weight,
 			bounded_vec,
-			transact_fee_amount
+			transact_fee_amount,
+			transact_dest_weight,
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::A, &ALICE), transfer_amount);
@@ -361,7 +363,7 @@ fn transfer_with_transact_self_reserve_sibling() {
 			ClearOrigin,
 			Transact {
 				origin_type: SovereignAccount,
-				require_weight_at_most: dest_weight,
+				require_weight_at_most: transact_dest_weight,
 				call: vec![].into(),
 			},
 		]);
@@ -397,7 +399,8 @@ fn transfer_with_transact_to_reserve_sibling() {
 
 	let transfer_amount = 50_000u128;
 	let transact_fee_amount = 10_000u128;
-	let dest_weight = 4_000;
+	let transfer_dest_weight = 4_000;
+	let transact_dest_weight = 4_000;
 
 	ParaA::execute_with(|| {
 		assert_ok!(ParaXTokens::transfer_with_transact(
@@ -405,9 +408,10 @@ fn transfer_with_transact_to_reserve_sibling() {
 			CurrencyId::B,
 			transfer_amount,
 			2, // PARA_B_ID,
-			dest_weight,
+			transfer_dest_weight,
 			bounded_vec.clone(),
-			transact_fee_amount
+			transact_fee_amount,
+			transact_dest_weight,
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::B, &ALICE), transfer_amount);
@@ -444,7 +448,7 @@ fn transfer_with_transact_to_reserve_sibling() {
 			ClearOrigin,
 			Transact {
 				origin_type: SovereignAccount,
-				require_weight_at_most: dest_weight,
+				require_weight_at_most: transact_dest_weight,
 				call: vec![].into(),
 			},
 		]);
@@ -478,7 +482,8 @@ fn transfer_with_transact_to_non_reserve_sibling() {
 
 	let transfer_amount = 50_000u128;
 	let transact_fee_amount = 10_000u128;
-	let dest_weight = 4_000;
+	let transfer_dest_weight = 4_000;
+	let transact_dest_weight = 4_000;
 
 	ParaA::execute_with(|| {
 		assert_ok!(ParaXTokens::transfer_with_transact(
@@ -486,9 +491,10 @@ fn transfer_with_transact_to_non_reserve_sibling() {
 			CurrencyId::R,
 			transfer_amount,
 			2, // PARA_B_ID,
-			dest_weight,
+			transfer_dest_weight,
 			bounded_vec,
-			transact_fee_amount
+			transact_fee_amount,
+			transact_dest_weight,
 		));
 
 		assert_eq!(ParaTokens::free_balance(CurrencyId::R, &ALICE), transfer_amount + 1_000);
@@ -522,7 +528,7 @@ fn transfer_with_transact_to_non_reserve_sibling() {
 			ClearOrigin,
 			Transact {
 				origin_type: SovereignAccount,
-				require_weight_at_most: dest_weight,
+				require_weight_at_most: transact_dest_weight,
 				call: vec![].into(),
 			},
 		]);

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -5,7 +5,7 @@ use codec::Encode;
 use cumulus_primitives_core::ParaId;
 use frame_support::{assert_err, assert_noop, assert_ok, traits::Currency, BoundedVec};
 use mock::{
-	para::{MyAccount32Hash, ParaWeigher},
+	para::{ParaAccount32Hash, ParaWeigher},
 	relay::RelayWeigher,
 	*,
 };
@@ -367,7 +367,7 @@ fn transfer_with_transact_self_reserve_sibling() {
 		]);
 		let transact_msg_weight = ParaWeigher::weight(&mut transact_msg).unwrap() as u128;
 
-		let user_sovereign_account = MyAccount32Hash::convert_ref(&user_multilocaiton).unwrap();
+		let user_sovereign_account = ParaAccount32Hash::convert_ref(&user_multilocaiton).unwrap();
 
 		assert_eq!(
 			ParaTokens::free_balance(CurrencyId::A, &user_sovereign_account),
@@ -450,7 +450,7 @@ fn transfer_with_transact_to_reserve_sibling() {
 		]);
 		let transact_msg_weight = ParaWeigher::weight(&mut transact_msg).unwrap() as u128;
 
-		let user_sovereign_account = MyAccount32Hash::convert_ref(&user_multilocaiton).unwrap();
+		let user_sovereign_account = ParaAccount32Hash::convert_ref(&user_multilocaiton).unwrap();
 		assert_eq!(
 			ParaTokens::free_balance(CurrencyId::B, &user_sovereign_account),
 			// AllTokensAreCreatedEqualToWeight means 1 to 1 mapping of the weight to fee
@@ -528,7 +528,7 @@ fn transfer_with_transact_to_non_reserve_sibling() {
 		]);
 		let transact_msg_weight = ParaWeigher::weight(&mut transact_msg).unwrap() as u128;
 
-		let user_sovereign_account = MyAccount32Hash::convert_ref(&user_multilocaiton).unwrap();
+		let user_sovereign_account = ParaAccount32Hash::convert_ref(&user_multilocaiton).unwrap();
 
 		assert_eq!(
 			ParaTokens::free_balance(CurrencyId::R, &user_sovereign_account),

--- a/xtokens/src/tests.rs
+++ b/xtokens/src/tests.rs
@@ -324,7 +324,7 @@ fn transfer_with_transact_self_reserve_sibling() {
 			50_000,
 			2, // PARA_B_ID,
 			4_000,
-			bounded_vec.clone(),
+			bounded_vec,
 			// Will cost at 3_000
 			10_000
 		));


### PR DESCRIPTION
Signed-off-by: Georgi Zlatarev <georgi.zlatarev@manta.network>

- [x] bounded input
- [x] workaround the fact that the limit can't be less than u32 --> made it a pallet constant, not configurable for now
- [x] separate dest_weight for Transact
----------------------------------------------------------------------
- [x] transact_only extrinsic
----------------------------------------------------------------------
- [x] refund surplus
- [x] add to transact_only as well
----------------------------------------------------------------------
- [x] transfer_with_transact tests
- [x] assert with the user sovereign account as well
- [ ] relative view tests
- [ ] transact-only tests
----------------------------------------------------------------------
- [x] orml weights
----------------------------------------------------------------------
- [x] barrier
- [x] should work with Limited and Unlimited dest_weight
- [x] expect the Transact instruction
- [ ] inspect Transact - check encoded length, for this I need a small PR to polkadot to get encoded.len()
- [ ] inspect Transact - take_decode() and match against allowed calls, can be configurable set

- [x] expect the refund instructions as well
----------------------------------------------------------------------
- [x] min-xcm-fee case -> no need when only 1 currency is transferred
----------------------------------------------------------------------
- [x] documentation
----------------------------------------------------------------------
- [ ] manta tests
