### PR TITLE
NativeBarrier trait and use in Xtokens

### DIFF
--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -29,3 +29,11 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 		dest_weight_limit: WeightLimit,
 	) -> DispatchResult;
 }
+
+pub trait NativeBarrier<AccountId, Balance> {
+    fn update_xcm_native_transfers(account_id: &AccountId, amount: Balance);
+    fn ensure_xcm_transfer_limit_not_exceeded(
+        account_id: &AccountId,
+        amount: Balance,
+    ) -> DispatchResult;
+}

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -31,9 +31,10 @@ pub trait XcmTransfer<AccountId, Balance, CurrencyId> {
 }
 
 pub trait NativeBarrier<AccountId, Balance> {
-    fn update_xcm_native_transfers(account_id: &AccountId, amount: Balance);
-    fn ensure_xcm_transfer_limit_not_exceeded(
-        account_id: &AccountId,
-        amount: Balance,
-    ) -> DispatchResult;
+	fn update_xcm_native_transfers(account_id: &AccountId, amount: Balance);
+	fn ensure_xcm_transfer_limit_not_exceeded(account_id: &AccountId, amount: Balance) -> DispatchResult;
+}
+
+pub trait NativeChecker<CurrencyId> {
+	fn is_native(currency_id: CurrencyId) -> bool;
 }

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -36,5 +36,5 @@ pub trait NativeBarrier<AccountId, Balance> {
 }
 
 pub trait NativeChecker<CurrencyId> {
-	fn is_native(currency_id: CurrencyId) -> bool;
+	fn is_native(currency_id: &CurrencyId) -> bool;
 }

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -38,17 +38,3 @@ pub trait NativeBarrier<AccountId, Balance> {
 pub trait NativeChecker<CurrencyId> {
 	fn is_native(currency_id: &CurrencyId) -> bool;
 }
-
-impl NativeBarrier<(), ()> for () {
-	fn update_xcm_native_transfers(_account_id: &(), _amount: ()) {}
-	fn ensure_xcm_transfer_limit_not_exceeded(_account_id: &(), _amount: ()) -> DispatchResult {
-		Ok(())
-	}
-}
-
-impl NativeChecker<()> for () {
-	fn is_native(_currency_id: &()) -> bool {
-		// Specific implementation for the unit type ()
-		true
-	}
-}

--- a/traits/src/xcm_transfer.rs
+++ b/traits/src/xcm_transfer.rs
@@ -38,3 +38,17 @@ pub trait NativeBarrier<AccountId, Balance> {
 pub trait NativeChecker<CurrencyId> {
 	fn is_native(currency_id: &CurrencyId) -> bool;
 }
+
+impl NativeBarrier<(), ()> for () {
+	fn update_xcm_native_transfers(_account_id: &(), _amount: ()) {}
+	fn ensure_xcm_transfer_limit_not_exceeded(_account_id: &(), _amount: ()) -> DispatchResult {
+		Ok(())
+	}
+}
+
+impl NativeChecker<()> for () {
+	fn is_native(_currency_id: &()) -> bool {
+		// Specific implementation for the unit type ()
+		true
+	}
+}

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -44,6 +44,7 @@ use xcm_executor::traits::{InvertLocation, WeightBounds};
 pub use module::*;
 use orml_traits::{
 	location::{Parse, Reserve},
+	xcm_transfer::NativeBarrier,
 	GetByKey, XcmTransfer,
 };
 
@@ -101,6 +102,9 @@ pub mod module {
 
 		/// Asset locations filter for outgoing transfers
 		type OutgoingAssetsFilter: Contains<Self::CurrencyId>;
+
+		///
+		type NativeBarrierType: NativeBarrier<Self::AccountId, Self::Balance>;
 
 		/// Means of measuring the weight consumed by an XCM message locally.
 		type Weigher: WeightBounds<Self::RuntimeCall>;
@@ -397,6 +401,10 @@ pub mod module {
 				Error::<T>::AssetDisabledForOutgoingTransfers
 			);
 
+			//if asset_id == <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get() {
+			<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, amount)?;
+			//}
+
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
 
@@ -422,6 +430,10 @@ pub mod module {
 				!T::OutgoingAssetsFilter::contains(&currency_id),
 				Error::<T>::AssetDisabledForOutgoingTransfers
 			);
+
+			//if asset_id == <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get() {
+			<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, amount)?;
+			//}
 
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
@@ -502,6 +514,10 @@ pub mod module {
 					!T::OutgoingAssetsFilter::contains(currency_id),
 					Error::<T>::AssetDisabledForOutgoingTransfers
 				);
+
+				//if asset_id == <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get() {
+				<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, *amount)?;
+				//}
 
 				let location: MultiLocation = T::CurrencyIdConvert::convert(currency_id.clone())
 					.ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;

--- a/xtokens/src/lib.rs
+++ b/xtokens/src/lib.rs
@@ -44,7 +44,7 @@ use xcm_executor::traits::{InvertLocation, WeightBounds};
 pub use module::*;
 use orml_traits::{
 	location::{Parse, Reserve},
-	xcm_transfer::NativeBarrier,
+	xcm_transfer::{NativeBarrier, NativeChecker},
 	GetByKey, XcmTransfer,
 };
 
@@ -104,7 +104,7 @@ pub mod module {
 		type OutgoingAssetsFilter: Contains<Self::CurrencyId>;
 
 		///
-		type NativeBarrierType: NativeBarrier<Self::AccountId, Self::Balance>;
+		type NativeBarrierType: NativeBarrier<Self::AccountId, Self::Balance> + NativeChecker<Self::CurrencyId>;
 
 		/// Means of measuring the weight consumed by an XCM message locally.
 		type Weigher: WeightBounds<Self::RuntimeCall>;
@@ -401,9 +401,9 @@ pub mod module {
 				Error::<T>::AssetDisabledForOutgoingTransfers
 			);
 
-			//if asset_id == <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get() {
-			<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, amount)?;
-			//}
+			if <T::NativeBarrierType>::is_native(&currency_id) {
+				<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, amount)?;
+			}
 
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
@@ -431,9 +431,9 @@ pub mod module {
 				Error::<T>::AssetDisabledForOutgoingTransfers
 			);
 
-			//if asset_id == <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get() {
-			<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, amount)?;
-			//}
+			if <T::NativeBarrierType>::is_native(&currency_id) {
+				<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, amount)?;
+			}
 
 			let location: MultiLocation =
 				T::CurrencyIdConvert::convert(currency_id).ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;
@@ -515,9 +515,9 @@ pub mod module {
 					Error::<T>::AssetDisabledForOutgoingTransfers
 				);
 
-				//if asset_id == <T::AssetConfig as AssetConfig<T>>::NativeAssetId::get() {
-				<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, *amount)?;
-				//}
+				if <T::NativeBarrierType>::is_native(&currency_id) {
+					<T::NativeBarrierType>::ensure_xcm_transfer_limit_not_exceeded(&who, *amount)?;
+				}
 
 				let location: MultiLocation = T::CurrencyIdConvert::convert(currency_id.clone())
 					.ok_or(Error::<T>::NotCrossChainTransferableCurrency)?;


### PR DESCRIPTION
* Add NativeBarrier and NativeChecker traits to orml-traits
* Use  in xTokens
* The idea is that if the asset-id that is being transacted is the native asset - there will be some limitation for a set of addresses on how much can be transferred per day